### PR TITLE
Update harvard-university-of-bath.csl

### DIFF
--- a/csl/harvard-university-of-bath.csl
+++ b/csl/harvard-university-of-bath.csl
@@ -301,7 +301,7 @@
       <text variable="page"/>
     </group>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <text macro="author-short"/>


### PR DESCRIPTION
Proposed change in relation to referencing **Harvard (Bath) Referencing Style** guidelines, section C point 11. "Four or more authors: cite the first author’s/editor’s name, followed by et al., which is a notation meaning 'and others'. You will need to list all the authors in your reference list."