### PR TITLE
Update harvard-university-of-bath.csl

### DIFF
--- a/csl/harvard-university-of-bath.csl
+++ b/csl/harvard-university-of-bath.csl
@@ -313,7 +313,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography entry-spacing="0" hanging-indent="true">
+  <bibliography entry-spacing="1" hanging-indent="false">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>


### PR DESCRIPTION
Amending: 
- entry spacing from "0" to "1" to allow for spacing between entries.
- hanging-indent from "true" to "false" to fall in line with the examples presented in the following referencing guide.
https://www.bath.ac.uk/library/gen/referencing/harvard-bath-print.pdf